### PR TITLE
Fix for Azure Update

### DIFF
--- a/examples/single-subscription/main.tf
+++ b/examples/single-subscription/main.tf
@@ -1,7 +1,7 @@
 # Configure the Microsoft Azure Provider
-# provider "azurerm" {
-#   features {}
-# }
+provider "azurerm" {
+  features {}
+}
 
 # creates resource group
 

--- a/examples/single-subscription/variables.tf
+++ b/examples/single-subscription/variables.tf
@@ -82,5 +82,5 @@ variable "subscription_ids_access" {
 
 variable "image" {
   type    = string
-  default = "deepfenceio/cloud-scanner:latest"
+  default = "deepfenceio/cloud-scanner:1.5.0"
 }

--- a/modules/services/vn-container/main.tf
+++ b/modules/services/vn-container/main.tf
@@ -64,7 +64,7 @@ resource "azurerm_container_group" "cg" {
   resource_group_name = var.resource_group_name
   ip_address_type     = "Private"
   os_type             = "Linux"
-  network_profile_id  = azurerm_network_profile.np.id
+  subnet_ids          = [azurerm_subnet.sn.id]
 
 
   container {


### PR DESCRIPTION
network_profile_id is now deprecated and subnet_ids are required if ip_address_type is Private